### PR TITLE
Add LoginController tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /public/hot
 /public/storage
 /storage/*.key
+/tests/coverage
 /vendor
 .env
 .env.backup

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Arr;
+use Tests\TestCase;
+
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testUserWithCorrectCredentialsCanLogIn()
+    {
+        // Arrange.
+        // Create a user and prep a login request.
+        $user = factory(User::class)->create(['password' => bcrypt('pw1234')]);
+        $user->createToken('Pixel 4');
+        $data = [
+            'device_name' => 'Pixel 4',
+            'email'       => $user->email,
+            'password'    => 'pw1234',
+        ];
+
+        // Act.
+        // Attempt to log in.
+        $response = $this->postJson('/api/login', $data);
+
+        // Assert.
+        // Ensure the user is logged in.
+        $response->assertSuccessful();
+        $this->assertNotNull($response->decodeResponseJson('data.token'));
+    }
+
+    public function testUserWithIncorrectCredentialsCannotLogIn()
+    {
+        // Arrange.
+        // Create a user and prep a login request.
+        $user = factory(User::class)->create(['password' => bcrypt('pw1234')]);
+        $user->createToken('Pixel 4');
+        $data = [
+            'device_name' => 'Pixel 4',
+            'email'       => $user->email,
+            'password'    => "I don't know the password.",
+        ];
+
+        // Act.
+        // Attempt to log in.
+        $response = $this->postJson('/api/login', $data);
+
+        // Assert.
+        // Ensure the user is NOT logged in.
+        $responseData = $response->decodeResponseJson();
+        $response->assertStatus(422);
+        $this->assertEquals('The given data was invalid.', $responseData['message']);
+        $this->assertEquals('The provided credentials are incorrect.', Arr::get($responseData, 'errors.email.0'));
+    }
+}


### PR DESCRIPTION
Just added a couple tests for the `LoginController`.

### Description
[Devin suggested I write tests](https://saytheirnames.slack.com/archives/C014JPRAU1Y/p1591470082107200) when I asked for some guidance in Slack. I ran a PHPUnit coverage report and wrote tests for the `LoginController` since PHPUnit labelled it as a project risk (will do more later).

![image](https://user-images.githubusercontent.com/468029/83980983-8de52700-a8df-11ea-99a6-36989675a3fc.png)

### This pull request includes:

- [ ] Bug Fix
- [ ] Feature
- [ ] Documentation Update
- [x] Tests

### The following changes were made:
1. Added `/tests/coverage` to `.gitignore` so coverage reports aren't accidentally added to the repo when running `phpunit --coverage-html tests/coverage`
    - I normally keep shell scripts for things like this and project setup in a `bin` folder, do we want to do something similar?
2. Added tests for un/successful attempts to log in.
    - The error message doesn't always make sense as the `testUserWithIncorrectCredentialsCannotLogIn` test indicates. Should we do something about that now?