### PR TITLE
Fixed misspelling in sharable links

### DIFF
--- a/app/Models/DonationLink.php
+++ b/app/Models/DonationLink.php
@@ -42,7 +42,7 @@ class DonationLink extends BaseModel implements Searchable
     protected static function booted()
     {
         static::saving(function ($model) {
-            $base = "https://www.saythiernames.io/donate/{$model->identifier}";
+            $base = "https://www.saytheirnames.io/donate/{$model->identifier}";
             $model->sharable_links = new SharableLinks([
                 'base' => $base,
                 'facebook' => "https://www.facebook.com/sharer/sharer.php?u=${base}",

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -66,7 +66,7 @@ class Person extends BaseModel implements Searchable
     protected static function booted()
     {
         static::saving(function ($model) {
-            $base = "https://www.saythiernames.io/profile/{$model->identifier}";
+            $base = "https://www.saytheirnames.io/profile/{$model->identifier}";
             $model->sharable_links = new SharableLinks([
                 'base' => $base,
                 'facebook' => "https://www.facebook.com/sharer/sharer.php?u=${base}",

--- a/app/Models/PetitionLink.php
+++ b/app/Models/PetitionLink.php
@@ -42,7 +42,7 @@ class PetitionLink extends BaseModel implements Searchable
     protected static function booted()
     {
         static::saving(function ($model) {
-            $base = "https://www.saythiernames.io/sign/{$model->identifier}";
+            $base = "https://www.saytheirnames.io/sign/{$model->identifier}";
             $model->sharable_links = new SharableLinks([
                 'base' => $base,
                 'facebook' => "https://www.facebook.com/sharer/sharer.php?u=${base}",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Why is this change required? What problem does it solve? Are there any references to link (e.g., Slack conversation or Trello)-->
At the next deploy, page shares would be missing working links to the site.

### This pull request includes:

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation Update
- [ ] Tests

### The following changes were made:
<!--- List your changes in detail -->

I changed saythiernames.io to saytheirnames.io in App/Models