### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Welcome to the Say Their Names project. Our aim is to build an open-source platf
 That being said, this codebase isn't your typical open source project because it's not a library or package with a limited scope—it's our entire product.
 
 <div align="center">
-    <h3>Wan't to Contribute? Check out our other repositories</h3>
+    <h3>Want to Contribute? Check out our other repositories</h3>
     <p>
         <a href="https://github.com/Say-Their-Name/say-their-names-api">API</a>
     </p>


### PR DESCRIPTION
### Description
Small typo fix in the readme.

### This pull request includes:

- [ ] Bug Fix
- [ ] Feature
- [x] Documentation Update
- [ ] Tests

### The following changes were made:
Change `Wan't` to `Want` in the contributing section.

### Other:
The "Documentation Website" link goes to `https://github.com/Say-Their-Name/say-their-names-api#`. Unsure if that is intentional or not.

